### PR TITLE
Make version valid

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "slack-vote",
-  "version": "0.5",
+  "version": "0.5.0",
   "description": "A voting/polling backend for Slack outgoing webhook configurations",
   "main": "server.js",
   "scripts": {


### PR DESCRIPTION
`git push heroku master` fails for a non-semvar version string.
